### PR TITLE
(maint) Fix Project Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build status](https://ci.appveyor.com/api/projects/status/v7w84n21w9yjspq7/branch/master?svg=true)](https://ci.appveyor.com/project/puppetlabs/pdk-planning/branch/master)
+
 # pdk-planning
 
 A repository of roadmaps, feature proposals, and other planning resources for the [Puppet Development Kit].

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 max_jobs: 1
-image: WMF 5
+image: Visual Studio 2017
 # We only need the latest
 shallow_clone: true
 branches:
@@ -27,5 +27,5 @@ build_script:
     # Only trigger if the GTIHUB_TOKEN exists
     # Only trigger the project sync on a forced or scheduled build, NOT per PR.
     if ( ($null -ne $ENV:GITHUB_TOKEN) -and (($Env:APPVEYOR_SCHEDULED_BUILD -eq 'true') -or ($Env:APPVEYOR_FORCED_BUILD -eq 'true')) ) {
-        .\tools\SyncProjects.ps1
+      .\tools\SyncProjects.ps1
     }

--- a/tools/SyncProjects.ps1
+++ b/tools/SyncProjects.ps1
@@ -9,7 +9,7 @@ try {
   Import-Module JiraPS -ErrorAction Stop
 }
 catch {
-  Install-Module JiraPS -ErrorAction Stop
+  Install-Module JiraPS -ErrorAction Stop -RequiredVersion 2.11.1 -Force
   Import-Module JiraPS -ErrorAction Stop
 }
 


### PR DESCRIPTION
Due to AtlassianPS/JiraPS#372 the version of JiraPS
needs to be pinned to 2.11.1 to be used for the automation.  This pin can be
removed once this issue is fixed.