### PR TITLE
(PDK-1593) Update pdk config RFC

### DIFF
--- a/RFCs/0002-add-pdk-config.md
+++ b/RFCs/0002-add-pdk-config.md
@@ -221,7 +221,7 @@ Setting precedence is discussed in more detail below.
 
 #### User/Local Config
 
-The values for these config keys will be persisted in ~/.pdk/config (`%LOCALAPPDATA%\PDK\config` on Windows).
+The values for these config keys will be persisted in `~/.config/pdk/user_config.json` (`%LOCALAPPDATA%\PDK\user_config.json` on Windows).
 They are intended to be developer-specific settings and will not apply to another developer working on the same codebase.
 
 | Key | Description |

--- a/RFCs/0002-add-pdk-config.md
+++ b/RFCs/0002-add-pdk-config.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Introduce a PDK and module configuration subsystem with a new `pdk config` subcommand providing the user interface
+Introduce a PDK and project configuration subsystem with a new `pdk config` subcommand providing the user interface
 to read and write configuration keys and values.
 
 ## Background & Assumptions
@@ -45,27 +45,28 @@ rake tasks, some of which the PDK invokes.)
 
 ## Proposed Implementation Design
 
-Implement a new pdk subcommand, `pdk config` which will offer the following actions:
+Implement a new pdk subcommand, `pdk <get|set|remove> config` which will offer the following actions:
 
-  - `pdk config get [--format=<format>]`
+Ref: (Verb-Noun Reference)[https://docs.google.com/document/d/1zX0FJBAvAIK3d3L3QemD2FGQo3EsgMOD0Ha1BYHVYJE]
+
+  - `pdk get config [--format=<format>]`
 
     Lists the complete, currently resolved configuration, merging all available layers of config and presenting the
     formatted results.
 
-    If run from within a module, will show both user-level and module-level config.
+    If run from within a project, will show system, user and project level config.
 
-    If run outside of a module, will only show user-level config with an indication to the user that the command was not
-    invoked from within a module.
+    If run outside of a project, will only show system and user level config with an indication to the user that the command was not invoked from within a project.
 
 
-  - `pdk config get <key> [--format=<format>]`
+  - `pdk get config <key> [--format=<format>]`
 
     Retrieves a specific value from the resolved configuration.
 
     If `<key>` is a leaf node of the configuration graph, this command will return the raw value:
 
     ```
-    $ pdk config get user.default_template.url
+    $ pdk get config user.default_template.url
     https://github.com/puppetlabs/pdk-templates.git
     ```
 
@@ -73,7 +74,7 @@ Implement a new pdk subcommand, `pdk config` which will offer the following acti
     of all sub-keys of the given key:
 
     ```
-    $ pdk config get user.default_template
+    $ pdk get config user.default_template
     user.default_template.url = https://github.com/puppetlabs/pdk-templates.git
     user.default_template.ref = master
     ```
@@ -81,16 +82,16 @@ Implement a new pdk subcommand, `pdk config` which will offer the following acti
     You can also supply the `--format` option to control how keys and values are presented:
 
     ```
-    $ pdk config get user.default_template.url --format=json
+    $ pdk get config user.default_template.url --format=json
     { "user.default_template.url": "https://github.com/.../pdk-templates.git" }
     ```
 
     ```
-    $ pdk config get user.default_template --format=json
+    $ pdk get config user.default_template --format=json
     { "user.default_template.url": "https://github.com/.../pdk-templates.git", "user.default_template.ref": "master" }
     ```
 
-  - `pdk config set [--add] <key> <value>`
+  - `pdk set config [--add] <key> <value>`
 
     Sets, updates, or adds to the value(s) in the given configuration key and outputs the new value(s).
 
@@ -117,7 +118,7 @@ Implement a new pdk subcommand, `pdk config` which will offer the following acti
     - Known single value key, initial value:
 
       ```
-      $ pdk config set user.default_template.url "https://github.com/scotje/pdk-templates.git"
+      $ pdk set config user.default_template.url "https://github.com/scotje/pdk-templates.git"
       pdk (INFO): Set initial value of user.default_template.url to "..."
       https://github.com/scotje/pdk-templates.git
       ```
@@ -125,7 +126,7 @@ Implement a new pdk subcommand, `pdk config` which will offer the following acti
     - Known single value key, update value:
 
       ```
-      $ pdk config set user.default_template.url "https://github.com/example/repo.git"
+      $ pdk set config user.default_template.url "https://github.com/example/repo.git"
       pdk (INFO): Changed existing value of user.default_template.url from "..." to "..."
       https://github.com/example/repo.git
       ```
@@ -133,7 +134,7 @@ Implement a new pdk subcommand, `pdk config` which will offer the following acti
     - Known multi-value key, initial value:
 
       ```
-      $ pdk config set module.multi.example apple
+      $ pdk set config module.multi.example apple
       pdk (INFO): Added new value "apple" to module.multi.example
       apple
       ```
@@ -141,7 +142,7 @@ Implement a new pdk subcommand, `pdk config` which will offer the following acti
     - Known multi-value key, additional value:
 
       ```
-      $ pdk config set module.multi.example banana
+      $ pdk set config module.multi.example banana
       pdk (INFO): Added new value "banana" to module.multi.example
       apple
       banana
@@ -150,7 +151,7 @@ Implement a new pdk subcommand, `pdk config` which will offer the following acti
     - Known multi-value key, duplicate value:
 
       ```
-      $ pdk config set module.multi.example apple
+      $ pdk set config module.multi.example apple
       pdk (INFO): No changes made to module.multi.example as it already contains value "apple"
       apple
       banana
@@ -159,7 +160,7 @@ Implement a new pdk subcommand, `pdk config` which will offer the following acti
     - User-defined key, initial value:
 
       ```
-      $ pdk config set module.x.example strawberry
+      $ pdk set config module.x.example strawberry
       pdk (INFO): Set initial value of modle.x.example to "strawberry"
       strawberry
       ```
@@ -167,13 +168,13 @@ Implement a new pdk subcommand, `pdk config` which will offer the following acti
     - User-defined key, append value:
 
       ```
-      $ pdk config set --add module.x.example orange
+      $ pdk set config --add module.x.example orange
       pdk (INFO): Added new value "orange" to module.x.example
       strawberry
       orange
       ```
 
-  - `pdk config del[ete] <key> [<value>|--all]`
+  - `pdk remove config <key> [<value>|--all]`
 
     Unset one more more values from the given configuration key.
 
@@ -205,10 +206,23 @@ Implement a new pdk subcommand, `pdk config` which will offer the following acti
 
 ### Proposed Configuration Keys
 
+#### System Config
+
+The values for these config keys will be persisted in `/opt/puppetlabs/pdk/config` (`%ProgramData%\PuppetLabs\PDK` on Windows).
+They are intended to be system-specific settings and will apply to all developer working on the same computer.
+
+These would typically be system level defaults of the same User/Local Config settings defined below. For example:
+
+In the RGBank company, they have their own PDK template store.
+To make it easier for onboarding new developers this is stored in the `system.module_defaults.template.url` key.
+Developers can choose to override this, by setting `user.module_defaults.template.url`
+
+Setting precedence is discussed in more detail below.
+
 #### User/Local Config
 
-The values for these config keys will be persisted in ~/.pdk/config. They are intended to be developer-specific settings
-and will not apply to another developer working on the same codebase.
+The values for these config keys will be persisted in ~/.pdk/config (`%LOCALAPPDATA%\PDK\config` on Windows).
+They are intended to be developer-specific settings and will not apply to another developer working on the same codebase.
 
 | Key | Description |
 | --- | --- |
@@ -220,44 +234,55 @@ and will not apply to another developer working on the same codebase.
 | [user.forge.api\_key] | Placeholder for future Forge API interactions. |
 | [user.forge.api\_secret] | Placeholder for future Forge API interactions. |
 
-#### Module-specific Config
+#### Project-specific Config
 
-The values for these config keys will be persisted in a new .pdk/config file within the module, the new file is intended
-to be checked into VCS and shared with other developers to ensure consistent application of the relevant PDK commands.
+The values for these config keys will be persisted in a new .pdk/config file within the project.
+Currently a project is only a Puppet Module but in the future this may extend to Control Repos or Bolt projects.
+The new file is intended to be checked into VCS and shared with other developers to ensure consistent application of the relevant PDK commands.
+
+For example, in a Module Project:
 
 | Key | Description |
 | --- | --- |
-| module.template.url | Template URL to use for this module. |
-| module.template.ref | Template ref to use for this module. Note that this will differ from what is currently stored in metadata.json, this value will be the “desired” reference (e.g. a branch name) but not the specific commit that the module was last updated to. |
-| module.template.custom.[...] | Filename based keys with associated config hashes to govern how the template should be applied to this specific module. Supersedes existing .sync.yml settings. |
-| module.test.fixtures.[...] | List of additional modules, etc. and associated config hashes needed in order to run unit tests for this module. Supersedes existing .fixtures.yml settings. |
-| module.x.[...] | Arbitrary keys and values to be utilized by users to persist data between module developers. Can be used as a basic shared data store for custom developer Rake tasks, etc. |
+| project.template.url | Template URL to use for this module. |
+| project.template.ref | Template ref to use for this module. Note that this will differ from what is currently stored in metadata.json, this value will be the “desired” reference (e.g. a branch name) but not the specific commit that the module was last updated to. |
+| project.template.custom.[...] | Filename based keys with associated config hashes to govern how the template should be applied to this specific module. Supersedes existing .sync.yml settings. |
+| project.test.fixtures.[...] | List of additional modules, etc. and associated config hashes needed in order to run unit tests for this module. Supersedes existing .fixtures.yml settings. |
+| project.x.[...] | Arbitrary keys and values to be utilized by users to persist data between module developers. Can be used as a basic shared data store for custom developer Rake tasks, etc. |
 
-### More About `module.x`
+### More About `project.x`
 
-The `module.x` configuration key space is intended to be used by module developers and third-party tool developers to
-persist configuration data that is relevant to all developers of a module. Ultimately we want to avoid any need for
-users to add additional configuration files to their modules beyond what `pdk config` uses.
+The `project.x` configuration key space is intended to be used by project developers and third-party tool developers to
+persist configuration data that is relevant to all developers of a project. Ultimately we want to avoid any need for
+users to add additional configuration files to their projects beyond what `pdk config` uses.
 
-We will define and document best practices around the usage of the `module.x` key space for the community, including
+We will define and document best practices around the usage of the `project.x` key space for the community, including
 things like:
 
  - Namespace your custom configuration settings under a key that matches the name of your organization or tool name,
-   e.g. `module.x.mycompany`, `module.x.voxpupuli`, or `module.x.super_module_tool`.
+   e.g. `project.x.mycompany`, `project.x.voxpupuli`, or `project.x.super_module_tool`.
 
  - If your custom configuration is tool-specific, include a key and value that you can use to version your other
    configuration data. That way you can significantly change the configuration format for your tool in the future
-   without breaking older versions. E.g. `module.x.super_module_tool.config_version = 1`
+   without breaking older versions. E.g. `project.x.super_module_tool.config_version = 1`
 
  - Plus any other best practices we come up with.
 
+### Setting Precedence
+
+The settings will typically be enforced using the following order:
+
+1. Project
+2. User/Local
+3. System
+
+Project settings have the highest precedence whereas System settings have the lowest.
+That is, if a setting is defined in both Project and System levels, only the Project level will take affect.
+
+Note that **typically** only the User and System settings will overlap.
+It is expected that there will be few, if at all, settings that makes sense in the Project and User levels
+
 ## Unresolved Questions
-
-- Do we need a “system”-level layer of config? (i.e. user-level config that is the default for all users of a system,
-  but can be overridden by actual user-level config.)
-
-  - _This would be relatively easy to add in the future if there is demand for it, and I haven't seen any compelling
-    need for it initially so I recommend we **not** implement this initially._
 
 - Should we assign expected types to the pre-defined configuration keys so that we can validate new values and report
   errors if the value cannot be coerced to the expected type?


### PR DESCRIPTION
Previously the RFC for the pdk config subcommand broke the verb-noun UX in PDK.
And one of the unanswered questions has been answered.  This commit:

* Update the RFC for the correct verb-noun usage
* Uses the name Project instead of Module. Better for future-proofing as the PDK
  will do more than just Puppet Modules
* A system level setting context is now required.  This adds this new level and
  talks about setting precedence
* Minor updates for semantic linebreaks