### PR TITLE
(maint) Relax project regex for versions

### DIFF
--- a/tools/SyncProjects.ps1
+++ b/tools/SyncProjects.ps1
@@ -198,7 +198,7 @@ Function Resize-String($Value, $MaxLength) {
 }
 
 Function Invoke-ParsePDKProject($project) {
-  if ($project.name -notmatch '^Release ([\w ]+)$') {
+  if ($project.name -notmatch '^Release ([\w\. ]+)$') {
     Write-Verbose "Project $($project.name) is not a release"
     return
   }


### PR DESCRIPTION
This commit updates the regex to allow Project names with a version, for example
`Release 1.16.0`